### PR TITLE
add Address Type argument

### DIFF
--- a/bin/bleah
+++ b/bin/bleah
@@ -117,7 +117,7 @@ def main():
             sys.stdout.flush()
 
             try:
-                dev = Peripheral(d)
+                dev = Peripheral(d,d.addrType)
 
                 print green('connected.')
                 

--- a/bleah/scan.py
+++ b/bleah/scan.py
@@ -129,6 +129,7 @@ class ScanReceiver(DefaultDelegate):
         tdata  = [
             [ 'Vendor', vlabel ],
             [ 'Allows Connections', clabel ],
+            [ 'Address Type', dev.addrType]
         ]
 
         for ( tag, desc, val ) in dev.getScanData():


### PR DESCRIPTION
Hello.

bluepy.btle.Peripheral class can accept device type("random" or "public").
As matters now stand, it can only connect "public" devices because default parameter value is "ADDR_TYPE_PUBLIC".