### PR TITLE
Add MTU support, Fix "BR/EDR Not Supported" flag

### DIFF
--- a/bin/bleah
+++ b/bin/bleah
@@ -75,6 +75,16 @@ def check_args(args):
             print "! Invalid handle:", args.handle, "\n"
             quit()
 
+    if args.mtu is not None:
+        try:
+            args.mtu=int(args.mtu)
+            # 23 byte are the default ATT_MTU size, according to the standard a maximum of 512 bytes are allowed
+            if args.mtu < 23 or args.mtu > 512:
+              raise ValueError
+        except ValueError:
+            print "! Invalid mtu:", args.mtu, "\n"
+            quit()
+
 def skip_device( args, dev ):
     if args.mac is not None and dev.addr != args.mac:
         return True
@@ -100,6 +110,7 @@ def main():
     parser.add_argument('-n', '--handle', action='store', type=str, default=None, help='Write data to this characteristic handle (requires --mac and --data).' )
     parser.add_argument('-d', '--data', action='store', type=str, default=None, help='Data to be written as a quoted string or as hex ( 0xdeadbeef... ).' )
     parser.add_argument('-r', '--datafile', action='store', type=str, default=None, help='Read data to be written from this file.' )
+    parser.add_argument('-m', '--mtu', action='store', type=int, default=None, help='Set MTU.' )
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -121,6 +132,8 @@ def main():
 
             try:
                 dev = Peripheral(d,d.addrType)
+                if args.mtu:
+                  dev.setMTU(args.mtu)
 
                 print green('connected.')
                 

--- a/bleah/scan.py
+++ b/bleah/scan.py
@@ -103,7 +103,7 @@ class ScanReceiver(DefaultDelegate):
             bits.append( 'LE General Discoverable' )
 
         if self._isBitSet( flags, 2 ):
-            bits.append( 'BR/EDR' )
+            bits.append( 'BR/EDR Not Supported' )
 
         if self._isBitSet( flags, 3 ):
             bits.append( 'LE + BR/EDR Controller Mode' )


### PR DESCRIPTION
Edit: I think I need to explain my changes a bit better.

During a recent test of a BLE device bleah would just hang. After some debugging it turned out that it tried to read a characteristic which was longer than 20 bytes. After modifying the ATT_MTU it worked.
According to the specification a valid ATT_MTU is 23 to 512 bytes.

The BR/EDR flag is a strange thing. When the flag is set, it actually means "Sorry I don't support BR/EDR". Again I came across this during a test. I wondered why the device wouldn't respond to BR/EDR stuff, though bleah said it does support it.  See also:  "Supplement to Bluetooth Core Specification v7 Part A, 1.3" (https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=421047, page 12)

Thinking about the BR/EDR flag change, I wondered if it would be better to do something like that:

`if not self._isBitSet( flags, 2 ):
    bits.append( 'BR/EDR' )`
