### PR TITLE
Fixing AttributeError when running a scan in python3

### DIFF
--- a/bleah/scan.py
+++ b/bleah/scan.py
@@ -140,7 +140,7 @@ class ScanReceiver(DefaultDelegate):
             elif tag in [8, 9]:
                 try:
                     tdata.append([ desc, yellow( val.decode('utf-8') ) ])
-                except UnicodeEncodeError:
+                except (UnicodeEncodeError, AttributeError):
                     tdata.append([ desc, yellow( repr(val) ) ])
             else:
                 tdata.append([ desc, repr(val) ])


### PR DESCRIPTION
Running python 3.6.5, I get an attribute error at this point, not sure if it's still necessary to catch the UnicodeEncodeError.